### PR TITLE
Use empty string as server id instead of undefined

### DIFF
--- a/src/Network/PushNotify/APN.hs
+++ b/src/Network/PushNotify/APN.hs
@@ -504,7 +504,7 @@ newConnection aci = do
           castore <- getSystemCertificateStore
           let clip = ClientParams
                   { clientUseMaxFragmentLength=Nothing
-                  , clientServerIdentification=(T.unpack hostname, undefined)
+                  , clientServerIdentification=(T.unpack hostname, "")
                   , clientUseServerNameIndication=True
                   , clientWantSessionResume=Nothing
                   , clientShared=def
@@ -527,7 +527,7 @@ newConnection aci = do
 
               clip = ClientParams
                   { clientUseMaxFragmentLength=Nothing
-                  , clientServerIdentification=(T.unpack hostname, undefined)
+                  , clientServerIdentification=(T.unpack hostname, "")
                   , clientUseServerNameIndication=True
                   , clientWantSessionResume=Nothing
                   , clientShared=shared


### PR DESCRIPTION
Undefined is being evaluated with new tls upgrade. Pass in an empty str as server id instead